### PR TITLE
Adds default return in case of failure

### DIFF
--- a/safe-access.js
+++ b/safe-access.js
@@ -8,7 +8,7 @@
   }
 }(this, function() {
 
-  return function access(obj, accessStr) {
+  return function access(obj, accessStr, defaultReturn) {
     // auto-curry here
     if (isUndefined(accessStr)) {
       return access.bind(null, obj);
@@ -27,7 +27,7 @@
 
     if (isUndefined(obj) || isNull(obj) ||
         (isTokenFunctionCall(currentToken) && !isFunction(obj))) {
-      return undefined;
+      return defaultReturn;
     }
 
     if (isTokenFunctionCall(currentToken)) {


### PR DESCRIPTION
Very often we want to use a default value in case it doesn't exist.

``` javascript
var items = access(object, "path.to[0].myarray", [])

items.map((i) => console.log(i))
```
